### PR TITLE
Add snapshot monitoring to zabbix-pve

### DIFF
--- a/zabbix-pve/template-os-pve.xml
+++ b/zabbix-pve/template-os-pve.xml
@@ -606,6 +606,35 @@ Updated: 2018/08/01</description>
 							<request_method>POST</request_method>
 						</item_prototype>
 						<item_prototype>
+							<name>{#PVENAME} Snapshots</name>
+							<type>DEPENDENT</type>
+							<key>pve.vm.snaps[{#PVEID}]</key>
+							<delay>0</delay>
+							<units>snapshots</units>
+							<applications>
+								<application>
+									<name>PVE VM</name>
+								</application>
+							</applications>
+							<preprocessing>
+								<step>
+									<type>REGEX</type>
+									<params>snapshots:(.+)
+\1</params>
+								</step>
+							</preprocessing>
+							<master_item>
+								<key>pve.vm.master[{#PVEID}]</key>
+							</master_item>
+							<trigger_prototypes>
+								<trigger_prototype>
+									<expression>{last()}&lt;&gt;0</expression>
+									<name>{#PVENAME} has snapshots</name>
+									<priority>INFO</priority>
+								</trigger_prototype>
+							</trigger_prototypes>
+						</item_prototype>
+						<item_prototype>
 							<name>{#PVENAME} Status</name>
 							<type>DEPENDENT</type>
 							<key>pve.vm.status[{#PVEID}]</key>

--- a/zabbix-pve/zabbix_pve
+++ b/zabbix-pve/zabbix_pve
@@ -108,6 +108,18 @@ function getdata() {
       test "$vms" != "" && sed -i "s/pool:/pool:$pool/" $vms 2> /dev/null
    done
 
+   for lxc in $($CURL/nodes/localhost/lxc | jq -r '.data[].vmid')
+   do
+      snaps=$($CURL/nodes/localhost/lxc/$lxc/snapshot | jq -r '.data[].name' | awk '{ if ($1 !="current") print $1}' | wc -l)
+      echo "snapshots:$snaps" >> vm_$lxc
+   done
+
+   for qm in $($CURL/nodes/localhost/qemu | jq -r '.data[].vmid')
+   do
+      snaps=$($CURL/nodes/localhost/qemu/$qm/snapshot | jq -r '.data[].name' | awk '{ if ($1 !="current") print $1}' | wc -l)
+      echo "snapshots:$snaps" >> vm_$qm
+   done
+
    $CURL/nodes/localhost/version | jq '.' | awk '
       /"version"/ { sub(/,$/, "", $2); gsub(/"/, "", $2);printf("version:%s\n", $2) > "pve_version";}
       /"release"/ { sub(/,$/, "", $2); gsub(/"/, "", $2);printf("release:%s\n",  $2) > "pve_version";}


### PR DESCRIPTION
This PR adds a metric to zabbix-pve to count the amount of snapshots per LXC/QM.

It will generate an informational trigger when snapshots are detected on a VM.